### PR TITLE
make bin/traceur.js bin/traceur-runtime.js

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,117 +1,117 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	
-	<parent>
-		<groupId>org.sonatype.oss</groupId>
-		<artifactId>oss-parent</artifactId>
-		<version>7</version>
-	</parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<packaging>jar</packaging>
-	<groupId>org.webjars</groupId>
-	<artifactId>traceur</artifactId>
-	<version>0.0.79-SNAPSHOT</version>
-	<name>traceur-compiler</name>
-	<description>google traceur ES6 compiler</description>
-	<url>http://webjars.org</url>
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
 
-	<licenses>
-		<license>
-			<name>BSD</name>
-			<url>https://github.com/google/traceur-compiler/blob/master/LICENSE</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
+    <packaging>jar</packaging>
+    <groupId>org.webjars</groupId>
+    <artifactId>traceur</artifactId>
+    <version>0.0.79-SNAPSHOT</version>
+    <name>traceur-compiler</name>
+    <description>google traceur ES6 compiler</description>
+    <url>http://webjars.org</url>
 
-	<scm>
-		<url>http://github.com/webjars/traceur</url>
-		<connection>scm:git:https://github.com/webjars/traceur.git</connection>
-		<developerConnection>scm:git:https://github.com/webjars/traceur.git</developerConnection>
-		<tag>HEAD</tag>
-	</scm>
+    <licenses>
+        <license>
+            <name>BSD</name>
+            <url>https://github.com/google/traceur-compiler/blob/master/LICENSE</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-	<developers>
-		<developer>
-			<id>warry</id>
-			<name>Maxime Dantec</name>
-		</developer>
-	</developers>
+    <scm>
+        <url>http://github.com/webjars/traceur</url>
+        <connection>scm:git:https://github.com/webjars/traceur.git</connection>
+        <developerConnection>scm:git:https://github.com/webjars/traceur.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<upstreamVersion>0.0.79</upstreamVersion>
-		<upstream.url>https://github.com/google/traceur-compiler</upstream.url>
-		<extractDir>${project.build.directory}/traceur-compiler-${upstreamVersion}</extractDir>
-		<destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
-		<requirejs>
-			{
-				"paths": {
-					"traceur-runtime": "traceur/bin/traceur-runtime"
-				},
-				shim: {
-					"traceur-runtime": {
-						"exports": "$traceurRuntime",
-					}
-				}
-			}
-		</requirejs>
-	</properties>
+    <developers>
+        <developer>
+            <id>warry</id>
+            <name>Maxime Dantec</name>
+        </developer>
+    </developers>
 
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.7</version>
-				<executions>
-					<execution>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							<target>
-								<get src="${upstream.url}/archive/${upstreamVersion}.zip" dest="${project.build.directory}/${upstreamVersion}.zip" />
-								<unzip src="${project.build.directory}/${upstreamVersion}.zip" dest="${project.build.directory}" />
-								<chmod perm="u+x">
-									<fileset dir="${extractDir}">
-										<include name="traceur" />
-										<include name="traceur-build" />
-									</fileset>
-								</chmod>
-								<exec executable="make" dir="${extractDir}">
-									<arg value="bin/traceur.js" />
-									<arg value="bin/traceur-runtime.js" />
-								</exec>
-								<move file="${extractDir}/package.json" toDir="${destDir}" />
-								<move file="${extractDir}/bin" toDir="${destDir}" />
-								<move file="${extractDir}/src" toDir="${destDir}" />
-							</target>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <upstreamVersion>0.0.79</upstreamVersion>
+        <upstream.url>https://github.com/google/traceur-compiler</upstream.url>
+        <extractDir>${project.build.directory}/traceur-compiler-${upstreamVersion}</extractDir>
+        <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
+        <requirejs>
+            {
+                "paths": {
+                    "traceur-runtime": "traceur/bin/traceur-runtime"
+                },
+                shim: {
+                    "traceur-runtime": {
+                        "exports": "$traceurRuntime",
+                    }
+                }
+            }
+        </requirejs>
+    </properties>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5</version>
-			</plugin>
-			
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.5.1</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>sonatype-nexus-staging</serverId>
-					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>true</autoReleaseAfterClose>
-				</configuration>
-			</plugin>
+    <build>
+        <plugins>
 
-		</plugins>
-	</build>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                         <configuration>
+                            <target>
+                                <get src="${upstream.url}/archive/${upstreamVersion}.zip" dest="${project.build.directory}/${upstreamVersion}.zip" />
+                                <unzip src="${project.build.directory}/${upstreamVersion}.zip" dest="${project.build.directory}" />
+                                <chmod perm="u+x">
+                                    <fileset dir="${extractDir}">
+                                        <include name="traceur" />
+                                        <include name="traceur-build" />
+                                    </fileset>
+                                </chmod>
+                                <exec executable="make" dir="${extractDir}">
+                                    <arg value="bin/traceur.js" />
+                                    <arg value="bin/traceur-runtime.js" />
+                                </exec>
+                                <move file="${extractDir}/package.json" toDir="${destDir}" />
+                                <move file="${extractDir}/bin" toDir="${destDir}" />
+                                <move file="${extractDir}/src" toDir="${destDir}" />
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.5.1</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>sonatype-nexus-staging</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
 
 </project>


### PR DESCRIPTION
Changes include:
1. Using ant task (instead of wagon) to download archive from git,
2. Using make (and npm, indirectly) to build traceur.js and traceur-runtime.js,
3. Tabs instead of spaces for indentation.

Sorry for 3rd, I used auto format and forgot about it.

I realize that building jar is now more system dependent (npm), however it seems to be a price worth paying. I believe that having compiled code is much more useful than just having sources.
