### PR TITLE
Add npm dependencies to the webjar in order to be able to actually run the traceur command line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
                                 <move file="${extractDir}/package.json" toDir="${destDir}" />
                                 <move file="${extractDir}/bin" toDir="${destDir}" />
                                 <move file="${extractDir}/src" toDir="${destDir}" />
+                                <move file="${extractDir}/node_modules" toDir="${destDir}" />
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
I'm building an sbt-traceur plugin (https://github.com/arielscarpinelli/sbt-traceur); and using this webjar for providing the traceur compiler to it.

In order allow traceur compiler to run, I need to include also in the webjar its node dependencies.

Thanks!
